### PR TITLE
Fix for issue #8

### DIFF
--- a/AutoLayoutHelper/UIView+AutoLayoutHelper.swift
+++ b/AutoLayoutHelper/UIView+AutoLayoutHelper.swift
@@ -53,8 +53,8 @@ extension UIView {
 
             let topConstraint: NSLayoutConstraint = self.addTopConstraint(toView: superview, relation: .Equal, constant: edges.top)
             let leftConstraint: NSLayoutConstraint = self.addLeftConstraint(toView: superview, relation: .Equal, constant: edges.left)
-            let bottomConstraint: NSLayoutConstraint = self.addBottomConstraint(toView: superview, relation: .Equal, constant: edges.bottom)
-            let rightConstraint: NSLayoutConstraint = self.addRightConstraint(toView: superview, relation: .Equal, constant: edges.right)
+            let bottomConstraint: NSLayoutConstraint = self.addBottomConstraint(toView: superview, relation: .Equal, constant: -edges.bottom)
+            let rightConstraint: NSLayoutConstraint = self.addRightConstraint(toView: superview, relation: .Equal, constant: -edges.right)
             
             constraints = [topConstraint, leftConstraint, bottomConstraint, rightConstraint]
         }

--- a/AutoLayoutHelper/ViewController.swift
+++ b/AutoLayoutHelper/ViewController.swift
@@ -34,10 +34,7 @@ class ViewController: UIViewController {
         redView.backgroundColor = UIColor.redColor()
         self.view.addSubview(redView)
 
-        redView.addTopConstraint(toView: redView.superview, constant: 10.0)
-        redView.addLeftConstraint(toView: redView.superview, constant: 10.0)
-        redView.addRightConstraint(toView: redView.superview, constant: -10.0)
-        redView.addBottomConstraint(toView: redView.superview, constant: -10.0)
+        redView.fillSuperView(UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0))
     }
     
     private func createViewWithAddCenterXCenterYConstraint() {
@@ -58,7 +55,7 @@ class ViewController: UIViewController {
         blueView.translatesAutoresizingMaskIntoConstraints = false
         blueView.backgroundColor = UIColor.blueColor()
         self.view.addSubview(blueView)
-
+//        blueView.hidden = true
         blueView.addWidthConstraint(toView: nil, constant: 80.0)
         blueView.addHeightConstraint(toView: nil, constant: 80.0)
     }

--- a/AutoLayoutHelperTests/UIView+AutoLayoutHelperTests.swift
+++ b/AutoLayoutHelperTests/UIView+AutoLayoutHelperTests.swift
@@ -101,7 +101,9 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
         
         let constraint = constraints[2]
 
-        self.verify(constraint, firstView: self.mockView, firstAttribute: .Bottom, secondView: self.mockSuperview, secondAttribute: .Bottom, relation: .Equal, constant: 10.0)
+        self.verify(constraint, firstView: self.mockView, firstAttribute: .Bottom, secondView: self.mockSuperview, secondAttribute: .Bottom, relation: .Equal, constant: -10.0)
+
+
     }
 
     func testFillSuperview_CreatesRightConstraint() {
@@ -114,7 +116,7 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
 
         let constraint = constraints[3]
 
-        self.verify(constraint, firstView: self.mockView, firstAttribute: .Right, secondView: self.mockSuperview, secondAttribute: .Right, relation: .Equal, constant: 10.0)
+        self.verify(constraint, firstView: self.mockView, firstAttribute: .Right, secondView: self.mockSuperview, secondAttribute: .Right, relation: .Equal, constant: -10.0)
     }
 
     


### PR DESCRIPTION
Fixes #8 a regression in <code>fillSuperview</code> method 

Note. the same thing happened on the Obj-C port ustwo/autolayout-helper-ios@d9fc906 :)
### Description
- Updated fillSuperview not applying negative bottom and right margins
- Updated unit tests
### Tasks
- [x] Code review
- [x] Unit tests
- [x] Manual Testing
### Screenshots

(The red view laid out using fillSuperview method and shows that insets for the bottom and right are applied negatively within the method) 

<img width="423" alt="screen shot 2015-12-07 at 10 47 43" src="https://cloud.githubusercontent.com/assets/1456685/11625070/05dba2c8-9cd0-11e5-8726-fb4bdf8e99ba.png">

cc @ylibatsya @danieladias @jamaine-ustwo @chris59david 
