### PR TITLE
Added support for Leading Trailing (and modified fillSuperView)

### DIFF
--- a/AutoLayoutHelper/UIView+AutoLayoutHelper.swift
+++ b/AutoLayoutHelper/UIView+AutoLayoutHelper.swift
@@ -61,7 +61,33 @@ extension UIView {
         
         return constraints
     }
-    
+
+
+    // MARK: - Leading
+
+    /**
+     Creates and adds an NSLayoutConstraint that relates this view's leading edge to some specified edge of another view, given a relation and offset. Default parameter values relate this view's leading edge to be equal to the leading edge of the other view.
+
+     @note The new constraint is added to this view's superview for you
+
+     :param: view      The other view to relate this view's layout to
+
+     :param: attribute The other view's layout attribute to relate this view's leading edge to e.g. the other view's trailing edge. Default value is NSLayoutAttribute.Leading
+
+     :param: relation  The relation of the constraint. Default value is NSLayoutRelation.Equal
+
+     :param: constant  An amount by which to offset this view's left from the other view's specified edge. Default value is 0
+
+     :returns: The created NSLayoutConstraint for this leading attribute relation
+     */
+    func addLeadingConstraint(toView view: UIView?, attribute: NSLayoutAttribute = .Leading, relation: NSLayoutRelation = .Equal, constant: CGFloat = 0.0) -> NSLayoutConstraint {
+
+        let constraint = self.createConstraint(attribute: .Leading, toView: view, attribute: attribute, relation: relation, constant: constant)
+        self.superview?.addConstraint(constraint)
+
+        return constraint
+    }
+
 
     // MARK: - Left
 

--- a/AutoLayoutHelper/UIView+AutoLayoutHelper.swift
+++ b/AutoLayoutHelper/UIView+AutoLayoutHelper.swift
@@ -37,13 +37,15 @@ extension UIView {
     // MARK: - Fill
     
     /**
-    Creates and adds an array of NSLayoutConstraint objects that relates this view's top, left, bottom and right to its superview, given an optional set of insets for each side. Default parameter values relate this view's top, left, bottom and right to its superview with no insets.
+    Creates and adds an array of NSLayoutConstraint objects that relates this view's top, leading, bottom and trailing to its superview, given an optional set of insets for each side. 
+     
+     Default parameter values relate this view's top, leading, bottom and trailing to its superview with no insets.
 
     @note The constraints are also added to this view's superview for you
 
-    :param: edges An amount insets to apply to the top, left, bottom and right constraint. Default value is UIEdgeInsetsZero
+    :param: edges An amount insets to apply to the top, leading, bottom and trailing constraint. Default value is UIEdgeInsetsZero
     
-    :returns: An array of 4 x NSLayoutConstraint objects (top, left, bottom , right) if the superview exists otherwise an empty array
+    :returns: An array of 4 x NSLayoutConstraint objects (top, leading, bottom, trailing) if the superview exists otherwise an empty array
     */
     func fillSuperView(edges: UIEdgeInsets = UIEdgeInsetsZero) -> [NSLayoutConstraint] {
         
@@ -51,12 +53,12 @@ extension UIView {
         
         if let superview = self.superview {
 
-            let topConstraint: NSLayoutConstraint = self.addTopConstraint(toView: superview, relation: .Equal, constant: edges.top)
-            let leftConstraint: NSLayoutConstraint = self.addLeftConstraint(toView: superview, relation: .Equal, constant: edges.left)
-            let bottomConstraint: NSLayoutConstraint = self.addBottomConstraint(toView: superview, relation: .Equal, constant: -edges.bottom)
-            let rightConstraint: NSLayoutConstraint = self.addRightConstraint(toView: superview, relation: .Equal, constant: -edges.right)
+            let topConstraint = self.addTopConstraint(toView: superview, constant: edges.top)
+            let leadingConstraint = self.addLeadingConstraint(toView: superview, constant: edges.left)
+            let bottomConstraint = self.addBottomConstraint(toView: superview, constant: -edges.bottom)
+            let trailingConstraint = self.addTrailingConstraint(toView: superview, constant: -edges.right)
             
-            constraints = [topConstraint, leftConstraint, bottomConstraint, rightConstraint]
+            constraints = [topConstraint, leadingConstraint, bottomConstraint, trailingConstraint]
         }
         
         return constraints

--- a/AutoLayoutHelper/UIView+AutoLayoutHelper.swift
+++ b/AutoLayoutHelper/UIView+AutoLayoutHelper.swift
@@ -63,26 +63,49 @@ extension UIView {
     }
 
 
-    // MARK: - Leading
+    // MARK: - Leading / Trailing
 
     /**
-     Creates and adds an NSLayoutConstraint that relates this view's leading edge to some specified edge of another view, given a relation and offset. Default parameter values relate this view's leading edge to be equal to the leading edge of the other view.
+     Creates and adds an `NSLayoutConstraint` that relates this view's leading edge to some specified edge of another view, given a relation and offset. Default parameter values relate this view's leading edge to be equal to the leading edge of the other view.
 
      @note The new constraint is added to this view's superview for you
 
      :param: view      The other view to relate this view's layout to
 
-     :param: attribute The other view's layout attribute to relate this view's leading edge to e.g. the other view's trailing edge. Default value is NSLayoutAttribute.Leading
+     :param: attribute The other view's layout attribute to relate this view's leading edge to e.g. the other view's trailing edge. Default value is `NSLayoutAttribute.Leading`
 
-     :param: relation  The relation of the constraint. Default value is NSLayoutRelation.Equal
+     :param: relation  The relation of the constraint. Default value is `NSLayoutRelation.Equal`
 
      :param: constant  An amount by which to offset this view's left from the other view's specified edge. Default value is 0
 
-     :returns: The created NSLayoutConstraint for this leading attribute relation
+     :returns: The created `NSLayoutConstraint` for this leading attribute relation
      */
     func addLeadingConstraint(toView view: UIView?, attribute: NSLayoutAttribute = .Leading, relation: NSLayoutRelation = .Equal, constant: CGFloat = 0.0) -> NSLayoutConstraint {
 
         let constraint = self.createConstraint(attribute: .Leading, toView: view, attribute: attribute, relation: relation, constant: constant)
+        self.superview?.addConstraint(constraint)
+
+        return constraint
+    }
+
+    /**
+     Creates and adds an `NSLayoutConstraint` that relates this view's trailing edge to some specified edge of another view, given a relation and offset. Default parameter values relate this view's trailing edge to be equal to the trailing edge of the other view.
+
+     @note The new constraint is added to this view's superview for you
+
+     :param: view      The other view to relate this view's layout to
+
+     :param: attribute The other view's layout attribute to relate this view's leading edge to e.g. the other view's trailing edge. Default value is `NSLayoutAttribute.Trailing`
+
+     :param: relation  The relation of the constraint. Default value is `NSLayoutRelation.Equal`
+
+     :param: constant  An amount by which to offset this view's left from the other view's specified edge. Default value is 0
+
+     :returns: The created `NSLayoutConstraint` for this trailing attribute relation
+     */
+    func addTrailingConstraint(toView view: UIView?, attribute: NSLayoutAttribute = .Trailing, relation: NSLayoutRelation = .Equal, constant: CGFloat = 0.0) -> NSLayoutConstraint {
+
+        let constraint = self.createConstraint(attribute: .Trailing, toView: view, attribute: attribute, relation: relation, constant: constant)
         self.superview?.addConstraint(constraint)
 
         return constraint

--- a/AutoLayoutHelper/ViewController.swift
+++ b/AutoLayoutHelper/ViewController.swift
@@ -11,6 +11,9 @@ import UIKit
 class ViewController: UIViewController {
 
     private var heightConstraint: NSLayoutConstraint!
+    private var filledView: UIView!
+    private var centerLabel: UILabel!
+    private var fixedWidthAndHeightView: UIView!
 
 
     // MARK: - View lifecycle
@@ -19,44 +22,62 @@ class ViewController: UIViewController {
 
         super.viewDidLoad()
 
+        // Examples
+
         self.createViewWithAddTopLeftRightBottomConstraints()
         self.createViewWithAddCenterXCenterYConstraint()
+        self.createViewWithLeadingTrailingConstraints()
         self.createViewWithAddWidthHeightConstraints()
     }
 
 
-    // MARK: - Constraints methods
+    // MARK: - Examples
 
     private func createViewWithAddTopLeftRightBottomConstraints() {
    
-        let redView: UIView = UIView(frame: CGRectZero)
-        redView.translatesAutoresizingMaskIntoConstraints = false
-        redView.backgroundColor = UIColor.redColor()
-        self.view.addSubview(redView)
+        self.filledView = UIView(frame: CGRectZero)
+        self.filledView.backgroundColor = UIColor.redColor()
+        self.view.addSubview(self.filledView)
 
-        redView.fillSuperView(UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0))
+        self.filledView.translatesAutoresizingMaskIntoConstraints = false
+        self.filledView.fillSuperView(UIEdgeInsetsMake(20.0, 20.0, 20.0, 20.0))
     }
     
     private func createViewWithAddCenterXCenterYConstraint() {
 
-        let label: UILabel = UILabel(frame: CGRectZero)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.backgroundColor = UIColor.yellowColor()
-        label.text = "Some centered text"
-        self.view.addSubview(label)
+        self.centerLabel = UILabel(frame: CGRectZero)
+        self.centerLabel.backgroundColor = UIColor.yellowColor()
+        self.centerLabel.text = "Some center label text"
+        self.view.addSubview(self.centerLabel)
 
-        label.addCenterXConstraint(toView: label.superview)
-        label.addCenterYConstraint(toView: label.superview)
+        self.centerLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.centerLabel.addCenterXConstraint(toView: self.centerLabel.superview)
+        self.centerLabel.addCenterYConstraint(toView: self.centerLabel.superview)
+    }
+
+    private func createViewWithLeadingTrailingConstraints() {
+
+        let leadingTrailingLabel = UILabel(frame: CGRectZero)
+        leadingTrailingLabel.backgroundColor = UIColor.purpleColor()
+        leadingTrailingLabel.text = "Some leading / trailing label text"
+        self.view.addSubview(leadingTrailingLabel)
+
+        leadingTrailingLabel.translatesAutoresizingMaskIntoConstraints = false
+        leadingTrailingLabel.addTopConstraint(toView: self.centerLabel, attribute: .Bottom, constant: 20.0)
+        leadingTrailingLabel.addLeadingConstraint(toView: self.centerLabel, attribute: .Leading, constant: 0.0)
+        leadingTrailingLabel.addTrailingConstraint(toView: self.centerLabel, attribute: .Trailing, constant: 0.0)
     }
 
     private func createViewWithAddWidthHeightConstraints() {
-        
-        let blueView: UIView = UIView(frame: CGRectZero)
-        blueView.translatesAutoresizingMaskIntoConstraints = false
-        blueView.backgroundColor = UIColor.blueColor()
-        self.view.addSubview(blueView)
-//        blueView.hidden = true
-        blueView.addWidthConstraint(toView: nil, constant: 80.0)
-        blueView.addHeightConstraint(toView: nil, constant: 80.0)
+
+        self.fixedWidthAndHeightView = UIView(frame: CGRectZero)
+        self.fixedWidthAndHeightView.backgroundColor = UIColor.blueColor()
+        self.view.addSubview(self.fixedWidthAndHeightView)
+
+        self.fixedWidthAndHeightView.translatesAutoresizingMaskIntoConstraints = false
+        self.fixedWidthAndHeightView.addTopConstraint(toView: self.fixedWidthAndHeightView.superview, constant: 20.0)
+        self.fixedWidthAndHeightView.addLeadingConstraint(toView: self.fixedWidthAndHeightView.superview, constant: 20.0)
+        self.fixedWidthAndHeightView.addWidthConstraint(toView: nil, constant: 80.0)
+        self.fixedWidthAndHeightView.addHeightConstraint(toView: nil, constant: 80.0)
     }
 }

--- a/AutoLayoutHelperTests/UIView+AutoLayoutHelperTests.swift
+++ b/AutoLayoutHelperTests/UIView+AutoLayoutHelperTests.swift
@@ -23,6 +23,7 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
         super.setUp()
         
         // Given
+        
         self.mockSuperview = UIView(frame: CGRectZero)
         self.mockView = UIView(frame: CGRectZero)
         self.mockView.translatesAutoresizingMaskIntoConstraints = false
@@ -159,6 +160,45 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
     }
 
 
+    // MARK: - Trailing
+
+    func testAddTrailingConstraint_AddsConstraint() {
+
+        // When
+
+        let rightConstraint: NSLayoutConstraint = self.mockView.addTrailingConstraint(toView: self.mockSuperview, attribute: .Leading, relation: .Equal, constant: 0.0);
+
+        // Then
+
+        let expectedResult = self.mockSuperview.constraints
+        let actualResult: [NSLayoutConstraint] = [rightConstraint]
+
+        XCTAssertEqual(expectedResult, actualResult, "Error: expected constraints to contain just the trailing constraint but instead it does not it contains \(expectedResult.count) constraints")
+    }
+
+    func testAddTrailingConstraint_CreatesTrailingConstraint() {
+
+        // When
+
+        let rightConstraint = self.mockView.addTrailingConstraint(toView: self.mockSuperview, attribute: .Leading, relation: .LessThanOrEqual, constant: 10.0);
+
+        // Then
+
+        self.verify(rightConstraint, firstView: self.mockView, firstAttribute: .Trailing, secondView: self.mockSuperview, secondAttribute: .Leading, relation: .LessThanOrEqual, constant: 10.0)
+    }
+
+    func testAddTrailingConstraint_CreatesTrailingConstraintWithDefaultValues() {
+
+        // When
+
+        let rightConstraint = self.mockView.addTrailingConstraint(toView: self.mockSuperview)
+
+        // Then
+
+        self.verify(rightConstraint, firstView: self.mockView, firstAttribute: .Trailing, secondView: self.mockSuperview, secondAttribute: .Trailing, relation: .Equal, constant: 0.0)
+    }
+
+
     // MARK: - Left
     
     func testAddLeftConstraint_AddsLeftConstraint() {
@@ -166,7 +206,7 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
         // When
         
         let leftConstraint: NSLayoutConstraint = self.mockView.addLeftConstraint(toView: self.mockSuperview, attribute: .Right, relation: .Equal, constant: 0.0)
-        
+
         // Then
 
         let expectedResult = self.mockSuperview.constraints

--- a/AutoLayoutHelperTests/UIView+AutoLayoutHelperTests.swift
+++ b/AutoLayoutHelperTests/UIView+AutoLayoutHelperTests.swift
@@ -79,7 +79,7 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
         self.verify(constraint, firstView: self.mockView, firstAttribute: .Top, secondView: self.mockSuperview, secondAttribute: .Top, relation: .Equal, constant: 10.0)
     }
     
-    func testFillSuperview_CreatesLeftConstraint() {
+    func testFillSuperview_CreatesLeadingConstraint() {
         
         // When
 
@@ -89,7 +89,7 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
 
         let constraint = constraints[1]
 
-        self.verify(constraint, firstView: self.mockView, firstAttribute: .Left, secondView: self.mockSuperview, secondAttribute: .Left, relation: .Equal, constant: 10.0)
+        self.verify(constraint, firstView: self.mockView, firstAttribute: .Leading, secondView: self.mockSuperview, secondAttribute: .Leading, relation: .Equal, constant: 10.0)
     }
     
     func testFillSuperview_CreatesBottomConstraint() {
@@ -107,7 +107,7 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
 
     }
 
-    func testFillSuperview_CreatesRightConstraint() {
+    func testFillSuperview_CreatesTrailingConstraint() {
         
         // When
 
@@ -117,7 +117,7 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
 
         let constraint = constraints[3]
 
-        self.verify(constraint, firstView: self.mockView, firstAttribute: .Right, secondView: self.mockSuperview, secondAttribute: .Right, relation: .Equal, constant: -10.0)
+        self.verify(constraint, firstView: self.mockView, firstAttribute: .Trailing, secondView: self.mockSuperview, secondAttribute: .Trailing, relation: .Equal, constant: -10.0)
     }
 
 

--- a/AutoLayoutHelperTests/UIView+AutoLayoutHelperTests.swift
+++ b/AutoLayoutHelperTests/UIView+AutoLayoutHelperTests.swift
@@ -119,7 +119,46 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
         self.verify(constraint, firstView: self.mockView, firstAttribute: .Right, secondView: self.mockSuperview, secondAttribute: .Right, relation: .Equal, constant: -10.0)
     }
 
-    
+
+    // MARK: - Leading
+
+    func testAddLeadingConstraint_AddsLeadingConstraint() {
+
+        // When
+
+        let leadingConstraint: NSLayoutConstraint = self.mockView.addLeadingConstraint(toView: self.mockSuperview, attribute: .Trailing, relation: .LessThanOrEqual, constant: 0.0)
+
+        // Then
+
+        let expectedResult = self.mockSuperview.constraints
+        let actualResult: [NSLayoutConstraint] = [leadingConstraint]
+
+        XCTAssertEqual(expectedResult, actualResult, "Error: expected constraints to contain just the leading constraint but instead it does not it contains \(expectedResult.count) constraints")
+    }
+
+    func testAddLeadingConstraint_CreatesLeadingConstraint() {
+
+        // When
+
+        let leadingConstraint = self.mockView.addLeadingConstraint(toView: self.mockSuperview, attribute: .Trailing, relation: .LessThanOrEqual, constant: 10.0)
+
+        // Then
+
+        self.verify(leadingConstraint, firstView: self.mockView, firstAttribute: .Leading, secondView: self.mockSuperview, secondAttribute: .Trailing, relation: .LessThanOrEqual, constant: 10.0)
+    }
+
+    func testAddLeadingConstraint_CreatesLeadingConstraintWithDefaultValues() {
+
+        // When
+
+        let leadingConstraint = self.mockView.addLeadingConstraint(toView: self.mockSuperview)
+
+        // Then
+
+        self.verify(leadingConstraint, firstView: self.mockView, firstAttribute: .Leading, secondView: self.mockSuperview, secondAttribute: .Leading, relation: .Equal, constant: 0.0)
+    }
+
+
     // MARK: - Left
     
     func testAddLeftConstraint_AddsLeftConstraint() {
@@ -134,7 +173,6 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
         let actualResult: [NSLayoutConstraint] = [leftConstraint]
 
         XCTAssertEqual(expectedResult, actualResult, "Error: expected constraints to contain just the left constraint but instead it does not it contains \(expectedResult.count) constraints")
-
     }
 
     func testAddLeftConstraint_CreatesLeftConstraint() {
@@ -159,7 +197,6 @@ class UIViewAutoLayoutHelperTests: XCTestCase {
         self.verify(leftConstraint, firstView: self.mockView, firstAttribute: .Left, secondView: self.mockSuperview, secondAttribute: .Left, relation: .Equal, constant: 0.0)
     }
 
-    
 
     // MARK: - Right
     

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This means you can relate a view to another view with the `NSLayoutAttribute` or
 
 #### Examples:
 
-##### Fill superview
+##### Fill Superview
 
 Add `NSLayoutConstraint` relations for a `UIView` relating its top, leading, trailing and bottom edges to it's superview 
 
@@ -57,9 +57,9 @@ or shorter you can omit the attributes:
     leftView.addTrailingConstraint(toView: superview, constant: -10.0)
     leftView.addBottomConstraint(toView: superview, constant: -10.0)
 
-or even shorter using `fillSuperview` (via [@danieladias](https://github.com/danieladias) )
+or even shorter using `fillSuperView` (via [@danieladias](https://github.com/danieladias) )
 
-    leftView.fillSuperview(UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0))
+    leftView.fillSuperView(UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0))
 
 ##### Centering
 

--- a/README.md
+++ b/README.md
@@ -1,79 +1,87 @@
 AutoLayoutHelper
 =======================
 
-UIView helper to easily create common Auto Layout Constraints for iOS
+`UIView` extension to easily create common Auto Layout Constraints for iOS.
 
 ### The Problem
 
-Using Auto Layout programatically can either be quite verbose i.e. building NSLayoutConstraint objects for each rule or error prone e.g. (using Visual Format Language strings)
+Using Auto Layout programatically (before [iOS 9's Auto Layout API](http://bartjacobs.com/auto-layout-fundamentals-working-with-layout-anchors/)) can either be quite verbose i.e. building `NSLayoutConstraint` objects for each rule or error prone e.g. (using [Visual Format Language strings](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/AutolayoutPG/VisualFormatLanguage/VisualFormatLanguage.html))
 
 ### A Solution
 
-We can make creating common NSLayoutConstraint relations into some reusable methods we can call on any class that subclasses UIView. We also ensure the constraint created gets added to the view's superview for you. This means you can relate a UIView or subclass you have to another view fairly quickly with the NSLayoutAttribute or NSLayoutRelation you need and in a way that looks part of the view's setup routine and helps us keep the code DRY.
+We can make creating common `NSLayoutConstraint` relations into some reusable methods we can call on any class that subclasses `UIView`. We also ensure the constraint created gets added to the view's superview for you. 
+
+This means you can relate a view to another view with the `NSLayoutAttribute` or `NSLayoutRelation` you need, as part of the view's setup and also helps us keep the code [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
 
 ### Dependencies 
 
 * [Xcode](https://itunes.apple.com/gb/app/xcode/id497799835?mt=12#)
 
+### Requirements
+
+* iOS 7+
+* tvOS 9+
+
 ### Installation
 
-- Add the UIView+LayoutConstraints.swift file to your project.
+- Add the `UIView+AutoLayoutHelper.swift` file to your Xcode project.
+- **Note**. CocoaPods support and Dynamic Framework target both coming soon!
 
 ### Usage
 
-Examples:
+#### Examples:
 
-Add NSLayoutConstraint relations for a UIView relating its left, top, bottom and right edges to it's superview 
+##### Fill superview
+
+Add `NSLayoutConstraint` relations for a `UIView` relating its top, leading, trailing and bottom edges to it's superview 
 
     // Create view
     
-    let leftView: UIView = UIView(frame: CGRectZero)
+    let leftView = UIView(frame: CGRectZero)
     leftView.backgroundColor = UIColor.redColor()
     self.view.addSubview(leftView)
     
     // Add constraints
-    
-    if let superview = leftView.superview {
         
-        leftView.setTranslatesAutoresizingMaskIntoConstraints(false)
-        
-        leftView.addTopConstraint(toView: superview, attribute: NSLayoutAttribute.Top, relation: NSLayoutRelation.Equal, constant: 10.0)
-        leftView.addLeftConstraint(toView: superview, attribute: NSLayoutAttribute.Left, relation: NSLayoutRelation.Equal, constant: 10.0)
-        leftView.addRightConstraint(toView: superview, attribute: NSLayoutAttribute.Right, relation: NSLayoutRelation.Equal, constant: -10.0)
-        leftView.addBottomConstraint(toView: superview, attribute: NSLayoutAttribute.Bottom, relation: NSLayoutRelation.Equal, constant: -10.0)
-    }
-
-or shorter assuming top to top, left to left, right to right and bottom to bottom you can omit the attribute: 
+    leftView.setTranslatesAutoresizingMaskIntoConstraints(false)
     
-    leftView.addTopConstraint(toView: superview, relation: NSLayoutRelation.Equal, constant: 10.0)
-    leftView.addLeftConstraint(toView: superview, relation: NSLayoutRelation.Equal, constant: 10.0)
-    leftView.addRightConstraint(toView: superview, relation: NSLayoutRelation.Equal, constant: -10.0)
+    leftView.addTopConstraint(toView: superview, attribute: NSLayoutAttribute.Top, relation: NSLayoutRelation.Equal, constant: 10.0)
+    leftView.addLeadingConstraint(toView: superview, attribute: NSLayoutAttribute.Leading, relation: NSLayoutRelation.Equal, constant: 10.0)
+    leftView.addTrailingConstraint(toView: superview, attribute: NSLayoutAttribute.Trailing, relation: NSLayoutRelation.Equal, constant: -10.0)
     leftView.addBottomConstraint(toView: superview, attribute: NSLayoutAttribute.Bottom, relation: NSLayoutRelation.Equal, constant: -10.0)
 
-or even more succinctly:
+or shorter you can omit the attributes:
+    
+    leftView.addTopConstraint(toView: superview, constant: 10.0)
+    leftView.addLeadingConstraint(toView: superview, constant: 10.0)
+    leftView.addTrailingConstraint(toView: superview, constant: -10.0)
+    leftView.addBottomConstraint(toView: superview, constant: -10.0)
 
-    [leftView fillSuperview:UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0)];
+or even shorter using `fillSuperview` (via [@danieladias](https://github.com/danieladias) )
 
+    leftView.fillSuperview(UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0))
 
-Add constraints to center a UIView in its superview both vertically (Y) and horizontally (X): 
+##### Centering
 
-    [label addCenterXConstraintToView:label.superview relation:NSLayoutRelationEqual constant:0.0];
-    [label addCenterYConstraintToView:label.superview relation:NSLayoutRelationEqual constant:0.0];
+Add constraints to center a `UIView` within its superview both vertically (Y axis) and horizontally (X axis): 
+
+    label.addCenterXConstraintToView(label.superview, relation: NSLayoutRelation.Equal, constant:0.0)
+    label.addCenterYConstraintToView(label.superview, relation: NSLayoutRelation.Equal, constant:0.0)
     
 Add constraints for a fixed width and height amount:
 
-    [view addWidthConstraintWithRelation:NSLayoutRelationEqual constant:100.0];
-    [view addHeightConstraintWithRelation:NSLayoutRelationEqual constant:80.0];
+    view.addWidthConstraintWithRelation: NSLayoutRelation.Equal, constant:100.0)
+    view.addHeightConstraintWithRelation: NSLayoutRelation.Equal, constant:80.0)
 
 Modify constraints (since the methods return them to you)
 
-    // Store the height constraint when its created
+    // Create a reference to the `NSLayoutConstraint` e.g. for height
         
-    self.heightConstraint = view.addHeightConstraint(NSLayoutRelation.Equal, constant: 80.0)
+    self.heightConstraint = view.addHeightConstraint(toView: nil, constant: 80.0)
     
     ...
     
-    // Modify height amount
+    // Update the height constant
     
     self.heightConstraint.constant = 30.0;
 
@@ -84,9 +92,7 @@ Modify constraints (since the methods return them to you)
         view.layoutIfNeeded()
     })
 
-### Team
+### Contributors
+
 * Development: [Shagun Madhikarmi](mailto:shagun@ustwo.com), [Daniela Dias](mailto:daniela@ustwo.com)
 
-### TODO: 
-- Create Dynamic Framework target
-- Tag 0.9 and 1.0


### PR DESCRIPTION
Fixes #10 
# Description
- Added `addLeadingConstraint` and `addTrailingConstraint` methods 
- Updated `fillSuperView` method to Leading and Trailing instead of Left and Right. **Note.** this should not be a breaking change (see [here](https://www.bitfountain.io/courses/auto-layout/leading-and-trailing-vs-left-and-right-ebe/c/22/l/1046))
- Updated Example / Sample code
- Unit Tests updated for the above
- Documentation updated for the above
- README updated for the above and fixes for typos and improvements to acknowledgements
# Status
- [x] Code review
- [x] Documentation
- [x] Example / Sample code
- [x] Unit Tests
- [x] Manual testing
- [x] README

<details>
<summary>

<strong>Screenshots</strong></summary>


<img width="494" alt="screen shot 2016-06-29 at 08 05 16" src="https://cloud.githubusercontent.com/assets/1456685/16443369/48f250ec-3dd0-11e6-9ff5-59f45b44befd.png">
<img width="432" alt="screen1" src="https://cloud.githubusercontent.com/assets/1456685/16443576/96481e70-3dd1-11e6-80a3-54ac0dc6b9da.png">
</details>
